### PR TITLE
adding @maximemelian@catcatnya.com

### DIFF
--- a/random/thebadspace.users.activitypub.block.list.tsv
+++ b/random/thebadspace.users.activitypub.block.list.tsv
@@ -54,3 +54,5 @@
 ###	https://social.tchncs.de/@Marcel_Gehlen/111760794986316387
 @mtr@local.abtmtr.link
 ###	https://local.abtmtr.link/objects/265234f7-7780-4cf6-a693-78c174361cb5
+@maximemelian@catcatnya.com
+### all my friends are already on it :(


### PR DESCRIPTION
reason is already included in the blocklist, why is this on a centralized commercial service anyway?